### PR TITLE
using builder callback notation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,19 +2,17 @@ import { Provider } from "react-redux";
 import CakeContainer from "./components/CakeContainer";
 import MilkContainer from "./components/MilkContainer";
 import store from "./features/store";
+import UsersList from "./components/UsersList";
 // import store from "./redux/Store";
-// import UsersList from "./components/UsersList";
 
 function App() {
   return (
-    <div>
-      <Provider store={store}>
-        <CakeContainer />
-        <MilkContainer />
-        <hr />
-        {/* <UsersList /> */}
-      </Provider>
-    </div>
+    <Provider store={store}>
+      <CakeContainer />
+      <MilkContainer />
+      <hr />
+      <UsersList />
+    </Provider>
   );
 }
 

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -1,22 +1,34 @@
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { fetchUsers } from "../redux/users/userActions";
+import { getAsyncUsers } from "../features/user/userSlice";
+// import { fetchUsers } from "../redux/users/userActions";
 
 function UsersList() {
   const dispatch = useDispatch();
-  const {loading, data, error } = useSelector((state) => state.users);
-  console.log(data);
+  const { loading, data, error } = useSelector((state) => state.user);
+  // console.log(data);
+  // this is the first method with redux
+  // useEffect(() => {
+  //   dispatch(fetchUsers());
+  // }, [dispatch]);
+  // second method with redux-toolkit
   useEffect(() => {
-    dispatch(fetchUsers());
+    dispatch(getAsyncUsers());
   }, [dispatch]);
   return (
     <div>
       <h2>Users List : </h2>
-      {loading?<p>Loading ...</p>:error?<p>{error}</p>:
-      <div>
-        {data.map(user=><li>{user.name}</li>)}
-      </div>
-      }
+      {loading ? (
+        <p>Loading ...</p>
+      ) : error ? (
+        <p>{error}</p>
+      ) : (
+        <div>
+          {data.map((user) => (
+            <li>{user.name}</li>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/store.js
+++ b/src/features/store.js
@@ -5,6 +5,7 @@
 import { configureStore } from "@reduxjs/toolkit";
 import cakeReducer from "./cake/cakeSlice";
 import milkReducer from "./milk/milkSlice";
+import userReducer from "./user/userSlice";
 
 // this is the first method with redux
 // const store = createStore(rootReducers, composeWithDevTools(applyMiddleware(thunk)));
@@ -14,6 +15,7 @@ const store = configureStore({
   reducer: {
     cake: cakeReducer,
     milk: milkReducer,
+    user: userReducer,
   },
 });
 export default store;

--- a/src/features/user/userSlice.js
+++ b/src/features/user/userSlice.js
@@ -41,7 +41,9 @@ export const getAsyncUsers = createAsyncThunk(
   "user/getAsyncUsers",
   async (_, { rejectWithValue }) => {
     try {
-      const { data } = axios.get("https://jsonplaceholder.typicode.com/users");
+      const { data } = await axios.get(
+        "https://jsonplaceholder.typicode.com/users"
+      );
       return data;
     } catch (error) {
       return rejectWithValue(error.message);
@@ -55,25 +57,47 @@ const initialState = {
   error: "",
 };
 
+// The object notation for `createSlice.extraReducers` has been removed. Please use the 'builder callback' notation instead
+// const userSlice = createSlice({
+//   name: "user",
+//   initialState,
+//   extraReducers: {
+//     [getAsyncUsers.pending]: (state, action) => {
+//       state.loading = true;
+//       state.data = [];
+//       state.error = "";
+//     },
+//     [getAsyncUsers.fulfilled]: (state, action) => {
+//       state.loading = false;
+//       state.data = action.payload;
+//       state.error = "";
+//     },
+//     [getAsyncUsers.rejected]: (state, action) => {
+//       state.loading = false;
+//       state.data = [];
+//       state.error = action.payload;
+//     },
+//   },
+// });
 const userSlice = createSlice({
   name: "user",
   initialState,
-  extraReducers: {
-    [getAsyncUsers.pending]: (state, action) => {
+  extraReducers: (builder) => {
+    builder.addCase(getAsyncUsers.pending, (state, action) => {
       state.loading = true;
       state.data = [];
       state.error = "";
-    },
-    [getAsyncUsers.fulfilled]: (state, action) => {
+    });
+    builder.addCase(getAsyncUsers.fulfilled, (state, action) => {
       state.loading = false;
       state.data = action.payload;
       state.error = "";
-    },
-    [getAsyncUsers.rejected]: (state, action) => {
+    });
+    builder.addCase(getAsyncUsers.rejected, (state, action) => {
       state.loading = false;
       state.data = [];
       state.error = action.payload;
-    },
+    });
   },
 });
 


### PR DESCRIPTION
 The object notation for `createSlice.extraReducers` has been removed. So I use the 'builder callback' notation instead.